### PR TITLE
Dashboard add Dev Container folder/workspace

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,4 +90,5 @@ export const FixedColorOptions = Object.freeze({
 
 export const RelevantExtensions = Object.freeze({
   remoteSSH: 'ms-vscode-remote.remote-ssh',
+  remoteCONTAINER: 'ms-vscode-remote.remote-containers',
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,9 +68,11 @@ export const USER_CANCELED = 'CanceledByUser'; // A symbol would be nice, but th
 export const ADD_NEW_PROJECT_TO_FRONT = false;
 
 export const SSH_REMOTE_PREFIX = 'vscode-remote://ssh-remote+';
+export const DEV_CONTAINER_PREFIX = 'vscode-remote://attached-container+';
 export const REMOTE_REGEX = /^vscode-remote:\/\/[^\+]+\+/;
 export const SSH_REGEX = /^((?<user>[^@\/]+)(\@))?(?<hostname>[^@\/\. ]+[^@\/ ]*)(?<folder>\/.*)*$/;
 export const WSL_DEFAULT_REGEX = /\\+wsl\$\\/i;
+export const CONTAINER_REGEX = /^(?<containername>[^@\/\. ]+[^@\/ ]*)(?<folder>\/.*)*$/;
 
 export const StartupOptions = Object.freeze({
   always: 'always',

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,7 +2,7 @@
 
 import { readFileSync } from 'fs';
 import * as vscode from 'vscode';
-import { SSH_REMOTE_PREFIX, WSL_DEFAULT_REGEX } from './constants';
+import { SSH_REMOTE_PREFIX, WSL_DEFAULT_REGEX, DEV_CONTAINER_PREFIX } from './constants';
 
 export class Group {
   id: string;
@@ -120,7 +120,7 @@ export interface GroupOrder {
 }
 
 export interface DashboardInfos {
-  relevantExtensionsInstalls: { remoteSSH };
+  relevantExtensionsInstalls: { remoteSSH, remoteCONTAINER };
   config: vscode.WorkspaceConfiguration;
   otherStorageHasData: boolean;
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -60,6 +60,8 @@ export class Project {
       (this.path.match(WSL_DEFAULT_REGEX) || this.path.startsWith('vscode-remote://wsl+'))
     ) {
       return ProjectRemoteType.WSL;
+    } else if (this.path && this.path.startsWith(DEV_CONTAINER_PREFIX)) {
+      return ProjectRemoteType.CONTAINER;
     }
 
     return ProjectRemoteType.None;
@@ -80,6 +82,26 @@ export function sanitizeProjectName(name: string) {
 
 export function getRemoteType(project: Project): ProjectRemoteType {
   return Project.prototype.getRemoteType.call(project);
+}
+
+export function getContainerHex(containerName: string | null, contextName="desktop-linux"): string | null {
+  if (containerName === null) {
+    return null;
+  }
+
+  let containerObject = {
+    containerName: "/" + containerName,
+    settings: {
+        context: contextName
+    }
+  };
+
+  let objString = JSON.stringify(containerObject);
+  let objectHex = "";
+  for (let i = 0; i < objString.length; i++) {
+      objectHex += objString.charCodeAt(i).toString(16);
+  }
+  return objectHex;
 }
 
 function generateRandomId(prepend: string = null) {
@@ -119,6 +141,7 @@ export enum ProjectRemoteType {
   None,
   SSH,
   WSL,
+  CONTAINER
 }
 
 export enum ReopenDashboardReason {

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -13,13 +13,13 @@ export function getSidebarContent() {
         <meta charset="UTF-8">
     </head>
     <body>
-        <p>If you are reading this, you have placed the Project Dashboard sidebar view into another sidebar container. 
+        <p>If you are reading this, you have placed the Project Dashboard sidebar view into another sidebar container.
         This view is not intended to be visible. Instead, it is simply a shortcut for opening the main Project Dashboard.</p>
 
-        <p>If you moved the sidebar view unintentionally and want to restore the original (intended) state, 
+        <p>If you moved the sidebar view unintentionally and want to restore the original (intended) state,
         please drag and drop this panel onto the sidebar.</p>
 
-        <p>If you encounter any problems or think this behaviour is misleading, 
+        <p>If you encounter any problems or think this behaviour is misleading,
         <a href="https://github.com/Kruemelkatze/vscode-dashboard/issues">please let me know.</a></p>
 
     </body>
@@ -84,7 +84,7 @@ export function getDashboardContent(
             ? getImportDiv()
             : getNoProjectsDiv()
         }
-        
+
             </div>
 
             ${infos.config.showAddGroupButtonTile ? getTempGroupSection(groups.length) : ''}
@@ -105,8 +105,8 @@ export function getDashboardContent(
         (function() {
             fitty('.project-header', ${JSON.stringify(FITTY_OPTIONS)});
 
-            window.vscode = acquireVsCodeApi();      
-            
+            window.vscode = acquireVsCodeApi();
+
             window.onload = () => {
                 initProjects();
                 initDnD();
@@ -143,7 +143,7 @@ function getGroupSection(group: Group, totalGroupCount: number, infos: Dashboard
         <div class="drop-signal"></div>
         ${group.projects.map((p) => getProjectDiv(p, infos)).join('\n')}
         ${showAddProjectButton ? getAddProjectDiv(group.id) : ''}
-    </div>       
+    </div>
 </div>`;
 }
 
@@ -155,9 +155,9 @@ function getTempGroupSection(totalGroupCount: number) {
     </div>
     <div class="group-list">
         <div class="drop-signal"></div>
-    </div>       
-</div>     
-    </div>       
+    </div>
+</div>
+    </div>
 </div>`;
 }
 
@@ -171,7 +171,7 @@ function getProjectDiv(project: Project, infos: DashboardInfos) {
   var lowerName = (project.name || '').toLowerCase();
 
   var isRemote = remoteType !== ProjectRemoteType.None;
-  var remoteExError = isRemote && !infos.relevantExtensionsInstalls.remoteSSH;
+  var remoteExError = isRemote && !infos.relevantExtensionsInstalls.remoteSSH && !infos.relevantExtensionsInstalls.remoteCONTAINER;
 
   return `
 <div class="project-container">
@@ -231,7 +231,7 @@ function getImportDiv() {
   return `
 <div class="project-container">
     <div class="project no-projects import-data" data-action="import-from-other-storage" data-nodrag>
-        Your dashboard is empty, but there are projects in your other storage. 
+        Your dashboard is empty, but there are projects in your other storage.
         <br/>
         This can happen if the storage option has been changed on a different device that is synced via Settings Sync.
         <p>Click here to import.</p>
@@ -264,7 +264,7 @@ function getProjectContextMenu() {
     </div>
 
     <div class="custom-context-menu-separator"></div>
-    
+
     <div class="custom-context-menu-item" data-action="color">
         Edit Color
     </div>
@@ -280,7 +280,7 @@ function getProjectContextMenu() {
 
 function getGroupContextMenu() {
   return `
-<div id="groupContextMenu" class="custom-context-menu">   
+<div id="groupContextMenu" class="custom-context-menu">
     <div class="custom-context-menu-item" data-action="add">
         Add Project
     </div>


### PR DESCRIPTION
I have developed a function that allows you to connect through Dev Container on the dashboard.

this is example of profile settings.
```json
{
    "isGitRepo": false,
    "id": "..",
    "name": "container",
    "path": "vscode-remote://attached-container+containername/path/to/src/test.code-workspace",
    "color": "#0000ff"
}
```

When you input a container name, create a hex id and connect based on that name.

<img width="601" alt="container" src="https://github.com/DanielNoveo/vscode-dashboard/assets/25794008/0fd7df36-6598-4ab9-ad94-8980866afcc0">

