### PR TITLE
Add Command - Open Project (with project name) In New Window

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,6 @@ This extension uses some code of following repositories only for educational pur
 
 > https://github.com/stuartcrobinson/unique-window-colors (NO LICENSE)
 
-> https://github.com/Kruemelkatze/vscode-dashboard (MIT)
+> origin repo : https://github.com/Kruemelkatze/vscode-dashboard (MIT)
+
+> forked repo : https://github.com/DanielNoveo/vscode-dashboard (MIT)

--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
       {
         "command": "dashboard.addProjectsFromFolder",
         "title": "Project Dashboard: Add Projects from Folder"
+      },
+      {
+        "command": "dashboard.openProjectWindow",
+        "title": "Project Dashboard: Open Project in New Window"
       }
     ],
     "keybindings": [
@@ -207,7 +211,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^14.14.8",
     "@types/vscode": "^1.51.0",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-clean-css": "^4.3.0",
     "gulp-mode": "^1.1.0",
     "gulp-sass": "^5.0.0",

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -125,8 +125,16 @@ export function activate(context: vscode.ExtensionContext) {
       await addProjectsFromFolder();
     },
   );
+  const openProjectWindowCommand = vscode.commands.registerCommand(
+    'dashboard.openProjectWindow',
+    async () => {
+      await openProjectInNewWindow();
+    },
+  );
+
 
   context.subscriptions.push(openCommand);
+  context.subscriptions.push(openProjectWindowCommand);
   context.subscriptions.push(addProjectCommand);
   context.subscriptions.push(removeProjectCommand);
   context.subscriptions.push(editProjectsManuallyCommand);
@@ -400,6 +408,25 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     showDashboard();
+  }
+
+  async function openProjectInNewWindow() {
+    try {
+      let projects = projectService.getProjectsFlat();
+      let projectPicks = projects.map((p) => ({ id: p.id, label: p.name }));
+
+      let selectedProjectPick = await vscode.window.showQuickPick(projectPicks);
+      if (selectedProjectPick == null) return;
+
+      let project =projectService.getProject(selectedProjectPick.id);
+      await openProject(project, ProjectOpenType.NewWindow);
+    } catch (error) {
+      if (error.message !== USER_CANCELED) {
+        vscode.window.showErrorMessage(`An error occured while open the project in new window.`);
+        throw error; // Rethrow error to make vscode log it
+      }
+      return;
+    }
   }
 
   async function removeGroup(groupId: string) {


### PR DESCRIPTION
I added a command that allows you to jump directly to the desired project or directory with the project name.

<img width="399" alt="command" src="https://github.com/DanielNoveo/vscode-dashboard/assets/25794008/7226b14e-a072-4878-b1a6-689d677f0f26">

You can open the new project, you want by entering the project name in the command palette.